### PR TITLE
Allow up to NC24

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,7 +27,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/files_frommail/master/screenshots/v0.1.0.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="18" max-version="18"/>
+		<nextcloud min-version="18" max-version="24"/>
 	</dependencies>
 
 	<settings>


### PR DESCRIPTION
Tested on NC24 RC1 (Arch Linux, NGINX, PHP 8.1, MariaDB) – works fine for me.

Fixes #40 